### PR TITLE
added DeletesCache annotation

### DIFF
--- a/packages/cached/README.md
+++ b/packages/cached/README.md
@@ -58,6 +58,7 @@ Useful when you want to limit use of memory to only hold commonly-used things or
   - [ClearAllCached](#clearallcached)
   - [StreamedCache](#streamedcache)
   - [CachePeek](#cachepeek)
+  - [DeletesCache](#deletescache)
 - [Contribution](#contribution)
 
 ## Motivation
@@ -410,6 +411,37 @@ Possible reasons why the generator gives an error
 - if method return type is incorrect
 - if method has different parameters then target function (excluding [Ignore], [IgnoreCache])
 - if method is not abstract
+
+### DeletesCache
+
+@DeletesCache annotaton is a method decorator that marks method to be processed by code generator. Methods preceeded by this annotation clear the cache of all specified methods, annotated with @Cached, if they complete with result.
+
+@DeletesCache annotation takes a list of cached methods that are affected by the use of annotated method, the cache of all specified methods is cleared on method success, but if an error occurs, the cache is not deleted and the error is rethrown.
+
+If there is a cached method:
+```dart
+@Cached()
+Future<SomeResponseType> getSthData() {
+  return dataSource.getData();
+}
+```
+
+Then a method that affects the cache of this method can be written as:
+```dart
+@DeletesCache(['getSthData'])
+Future<SomeResponseType> performOperation() {
+  ...
+  return data;
+}
+```
+
+All methods specified in @DeletesCache annotation must correspond to cached method names. If the performOperation method completes without an error, then the cache of getSthData will be cleared. 
+
+Throws an [InvalidGenerationSourceError]
+* if method with @cached annotation doesn't exist
+* if no target method names are specified
+* if specified target methods are invalid
+* if annotated method is abstract
 
 ## Contribution
 

--- a/packages/cached/example/bin/gen.dart
+++ b/packages/cached/example/bin/gen.dart
@@ -79,6 +79,18 @@ abstract class Gen implements _$Gen {
   @ClearCached('getDataWithCached')
   void clearDataCache();
 
+  /// Method annotated with @DeletesCache annotation will clear
+  /// cached results if it returns with value; however if this method
+  /// would throw exception, cached data would not be cleared
+  ///
+  /// IMPORTANT!
+  /// Method names passed in annotation must correspond to
+  /// valid cached method names
+  @DeletesCache(["getDataWithCached"])
+  Future<int> deletesCache() async {
+    return 1;
+  }
+
   /// Method with this annotation will clear cached values for all methods.
   @clearAllCached
   void clearAllCache();

--- a/packages/cached/example/pubspec.lock
+++ b/packages/cached/example/pubspec.lock
@@ -91,7 +91,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.3.0"
+    version: "1.3.1"
   cached_annotation:
     dependency: "direct main"
     description:

--- a/packages/cached/example/pubspec.yaml
+++ b/packages/cached/example/pubspec.yaml
@@ -7,10 +7,12 @@ environment:
   sdk: '>=2.16.1 <3.0.0'
 
 dependencies:
-  cached_annotation: ^1.3.0
+  cached_annotation: 
+    path: "../../cached_annotation"
   http: ^0.13.4
 
 dev_dependencies:
   build_runner: ^2.1.10
-  cached: ^1.3.0
+  cached: 
+    path: "../../cached"
   lints: ^1.0.0

--- a/packages/cached/lib/src/models/class_with_cache.dart
+++ b/packages/cached/lib/src/models/class_with_cache.dart
@@ -5,6 +5,7 @@ import 'package:cached/src/models/cached_method.dart';
 import 'package:cached/src/models/clear_all_cached_method.dart';
 import 'package:cached/src/models/clear_cached_method.dart';
 import 'package:cached/src/models/constructor.dart';
+import 'package:cached/src/models/deletes_cache_method.dart';
 import 'package:cached/src/models/streamed_cache_method.dart';
 import 'package:cached/src/utils/asserts.dart';
 import 'package:cached/src/utils/utils.dart';
@@ -23,6 +24,7 @@ class ClassWithCache {
     required this.clearMethods,
     required this.streamedCacheMethods,
     required this.cachePeekMethods,
+    required this.deletesCacheMethods,
     this.clearAllMethod,
   });
 
@@ -33,6 +35,7 @@ class ClassWithCache {
   final Iterable<ClearCachedMethod> clearMethods;
   final Iterable<StreamedCacheMethod> streamedCacheMethods;
   final Iterable<CachePeekMethod> cachePeekMethods;
+  final Iterable<DeletesCacheMethod> deletesCacheMethods;
   final ClearAllCachedMethod? clearAllMethod;
 
   factory ClassWithCache.fromElement(ClassElement element, Config config) {
@@ -111,6 +114,20 @@ class ClassWithCache {
 
     assertOneCachePeekPerCachedMethod(element.methods, cachePeekMethods);
 
+    final deletesCacheMethods = element.methods
+        .where((element) => DeletesCacheMethod.getAnnotation(element) != null)
+        .inspect(assertCorrectDeletesCacheMethodType)
+        .map(
+          (e) => DeletesCacheMethod.fromElement(
+            e,
+            config,
+            methodsWithTtls,
+          ),
+        )
+        .toList();
+
+    assertValidateDeletesCacheMethods(deletesCacheMethods, methods);
+
     return ClassWithCache(
       name: element.name,
       useStaticCache:
@@ -121,6 +138,7 @@ class ClassWithCache {
       constructor: constructor,
       clearAllMethod: clearAllMethod.firstOrNull,
       cachePeekMethods: cachePeekMethods,
+      deletesCacheMethods: deletesCacheMethods,
     );
   }
 }

--- a/packages/cached/lib/src/models/deletes_cache_method.dart
+++ b/packages/cached/lib/src/models/deletes_cache_method.dart
@@ -1,0 +1,72 @@
+import 'package:analyzer/dart/constant/value.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:cached/src/config.dart';
+import 'package:cached/src/models/param.dart';
+import 'package:cached_annotation/cached_annotation.dart';
+
+import 'package:source_gen/source_gen.dart';
+
+class DeletesCacheMethod {
+  const DeletesCacheMethod({
+    required this.name,
+    required this.methodNames,
+    required this.returnType,
+    required this.isAsync,
+    required this.params,
+    required this.isGenerator,
+    required this.ttlsToClear,
+  });
+
+  final String name;
+  final List<String> methodNames;
+  final String returnType;
+  final bool isGenerator;
+  final bool isAsync;
+  final Iterable<Param> params;
+  final List<String> ttlsToClear;
+
+  factory DeletesCacheMethod.fromElement(
+    MethodElement element,
+    Config config,
+    Set<String> ttlsToClear,
+  ) {
+    final annotation = getAnnotation(element);
+
+    List<String>? methodNames;
+
+    if (annotation != null) {
+      final reader = ConstantReader(annotation);
+      final methodNameField = reader.read('methodNames');
+
+      if (methodNameField.isList &&
+          !methodNameField.listValue.any(
+            (value) => value.toStringValue() == null,
+          )) {
+        methodNames = methodNameField.listValue
+            .map(
+              (e) => e.toStringValue()!,
+            )
+            .toList();
+      }
+    }
+
+    return DeletesCacheMethod(
+      name: element.name,
+      methodNames: methodNames ?? [],
+      returnType: element.returnType.getDisplayString(withNullability: true),
+      isAsync: element.isAsynchronous,
+      isGenerator: element.isGenerator,
+      params: element.parameters.map((e) => Param.fromElement(e, config)),
+      ttlsToClear: methodNames != null
+          ? ttlsToClear
+              .where((element) => methodNames!.contains(element))
+              .toList()
+          : [],
+    );
+  }
+
+  static DartObject? getAnnotation(MethodElement element) {
+    const methodAnnotationChecker = TypeChecker.fromRuntime(DeletesCache);
+    return methodAnnotationChecker.firstAnnotationOf(element);
+  }
+}

--- a/packages/cached/lib/src/templates/class_template.dart
+++ b/packages/cached/lib/src/templates/class_template.dart
@@ -4,6 +4,7 @@ import 'package:cached/src/templates/cache_peek_method_template.dart';
 import 'package:cached/src/templates/cached_method_template.dart';
 import 'package:cached/src/templates/clear_all_cached_method_template.dart';
 import 'package:cached/src/templates/clear_cached_method_template.dart';
+import 'package:cached/src/templates/deletes_cache_method_template.dart';
 import 'package:cached/src/templates/streamed_method_template.dart';
 import 'package:collection/collection.dart';
 
@@ -60,6 +61,18 @@ class ClassTemplate {
     final constructorParamTemplates =
         AllParamsTemplate(classWithCache.constructor.params);
 
+    final deletesCacheMethodTemplates = classWithCache.deletesCacheMethods.map(
+      (method) => DeletesCacheMethodTemplate(
+        method,
+        classWithCache.streamedCacheMethods
+            .where(
+              (streamedMethod) =>
+                  method.methodNames.contains(streamedMethod.targetMethodName),
+            )
+            .toList(),
+      ),
+    );
+
     return '''
 class _${classWithCache.name} with ${classWithCache.name} implements _\$${classWithCache.name} {
   _${classWithCache.name}(${constructorParamTemplates.generateThisParams()});
@@ -83,6 +96,8 @@ class _${classWithCache.name} with ${classWithCache.name} implements _\$${classW
   ${cachePeekMethodTemplates.map((e) => e.generateMethod()).join('\n\n')}
 
   ${clearAllMethodTemplate.generateMethod()}
+
+  ${deletesCacheMethodTemplates.map((e) => e.generateMethod()).join('\n\n')}
 }
 ''';
   }

--- a/packages/cached/lib/src/templates/deletes_cache_method_template.dart
+++ b/packages/cached/lib/src/templates/deletes_cache_method_template.dart
@@ -1,0 +1,47 @@
+import 'package:cached/src/models/deletes_cache_method.dart';
+import 'package:cached/src/models/streamed_cache_method.dart';
+import 'package:cached/src/templates/all_params_template.dart';
+import 'package:cached/src/utils/utils.dart';
+
+class DeletesCacheMethodTemplate {
+  DeletesCacheMethodTemplate(
+    this.method,
+    this.streamedCacheMethods,
+  ) : paramsTemplate = AllParamsTemplate(method.params);
+
+  final DeletesCacheMethod method;
+  final AllParamsTemplate paramsTemplate;
+  final List<StreamedCacheMethod>? streamedCacheMethods;
+
+  String generateMethod() {
+    final asyncModifier = isFuture(method.returnType) ? 'async' : '';
+    final awaitIfNeeded = isFuture(method.returnType) ? 'await' : '';
+
+    return '''
+    @override
+    ${method.returnType} ${method.name}(${paramsTemplate.generateParams()}) $asyncModifier {
+      final result = $awaitIfNeeded super.${method.name}(${paramsTemplate.generateParamsUsage()});
+
+      ${_generateClearMaps()}
+
+      return result;
+    }
+    ''';
+  }
+
+  String _generateClearMaps() {
+    return [
+      ...method.methodNames.map(
+        (methodToClear) => "${getCacheMapName(methodToClear)}.clear();",
+      ),
+      ...method.ttlsToClear.map(
+        (ttlToClearMethodName) =>
+            "${getTtlMapName(ttlToClearMethodName)}.clear();",
+      ),
+      ...streamedCacheMethods?.map(
+            (streamedMethod) => clearStreamedCache(streamedMethod),
+          ) ??
+          <String>[]
+    ].join("\n");
+  }
+}

--- a/packages/cached/lib/src/utils/asserts.dart
+++ b/packages/cached/lib/src/utils/asserts.dart
@@ -3,6 +3,7 @@ import 'package:cached/src/models/cache_peek_method.dart';
 import 'package:cached/src/models/cached_method.dart';
 import 'package:cached/src/models/clear_all_cached_method.dart';
 import 'package:cached/src/models/clear_cached_method.dart';
+import 'package:cached/src/models/deletes_cache_method.dart';
 import 'package:cached/src/models/streamed_cache_method.dart';
 import 'package:cached/src/utils/utils.dart';
 import 'package:source_gen/source_gen.dart';
@@ -197,5 +198,41 @@ void assertCorrectCachePeekMethodType(MethodElement element) {
       '[ERROR] `${element.name}` must be a abstract method',
       element: element,
     );
+  }
+}
+
+void assertCorrectDeletesCacheMethodType(MethodElement element) {
+  if (element.isAbstract) {
+    throw InvalidGenerationSourceError(
+      '[ERROR] `${element.name}` cant be an abstract method',
+      element: element,
+    );
+  }
+}
+
+void assertValidateDeletesCacheMethods(
+  Iterable<DeletesCacheMethod> deletesCacheMethods,
+  Iterable<CachedMethod> methods,
+) {
+  for (final deletesCacheMethod in deletesCacheMethods) {
+    final invalidTargetMethods = deletesCacheMethod.methodNames.where(
+      (method) => !methods.map((e) => e.name).contains(method),
+    );
+
+    if (invalidTargetMethods.isNotEmpty) {
+      final message = invalidTargetMethods
+          .map(
+            (invalidTargetMethod) =>
+                "[ERROR] $invalidTargetMethod is not a valid target for ${deletesCacheMethod.name}",
+          )
+          .join('\n');
+      throw InvalidGenerationSourceError(message);
+    }
+
+    if (deletesCacheMethod.methodNames.isEmpty) {
+      throw InvalidGenerationSourceError(
+        '[ERROR] No target method names specified for ${deletesCacheMethod.name}',
+      );
+    }
   }
 }

--- a/packages/cached/pubspec.yaml
+++ b/packages/cached/pubspec.yaml
@@ -12,7 +12,8 @@ environment:
 dependencies:
   analyzer: ">=3.0.0 <5.0.0"
   build: ^2.3.0
-  cached_annotation: ^1.3.0
+  cached_annotation:
+    path: "../cached_annotation"
   collection: ^1.16.0
   meta: ^1.7.0
   source_gen: ^1.2.2

--- a/packages/cached/test/deletes_cache_method_generation_test.dart
+++ b/packages/cached/test/deletes_cache_method_generation_test.dart
@@ -1,0 +1,30 @@
+import 'package:cached/src/cached_generator.dart';
+import 'package:cached/src/config.dart';
+import 'package:path/path.dart' as p;
+import 'package:source_gen_test/source_gen_test.dart';
+
+Future<void> main() async {
+  initializeBuildLogTracking();
+  const _expectedAnnotatedTests = {
+    'ShouldHaveCachedMethod',
+    'NoMethodsSpecified',
+    'InvalidTarget',
+    'CantBeAbstract',
+    'ValidNoTtl',
+    'ValidTtl',
+    'ValidStreamed',
+    'ValidTwoMethods',
+    'ValidSync',
+  };
+
+  final reader = await initializeLibraryReaderForDirectory(
+    p.join('test', 'inputs'),
+    'deletes_cache_method_generation_test_input.dart',
+  );
+
+  testAnnotatedElements(
+    reader,
+    const CachedGenerator(config: Config()),
+    expectedAnnotatedTests: _expectedAnnotatedTests,
+  );
+}

--- a/packages/cached/test/inputs/deletes_cache_method_generation_test_input.dart
+++ b/packages/cached/test/inputs/deletes_cache_method_generation_test_input.dart
@@ -1,0 +1,445 @@
+import 'package:cached_annotation/cached_annotation.dart';
+import 'package:source_gen_test/annotations.dart';
+
+@ShouldThrow(
+  "[ERROR] notCachedMethod is not a valid target for deleteCache",
+  element: false,
+)
+@withCache
+abstract class ShouldHaveCachedMethod {
+  factory ShouldHaveCachedMethod() = _ShouldHaveCachedMethod;
+
+  Future<int> notCachedMethod(int x) async {
+    return 1;
+  }
+
+  @DeletesCache(['notCachedMethod'])
+  Future<void> deleteCache() async {}
+}
+
+@ShouldThrow(
+  "[ERROR] No target method names specified for deleteCache",
+  element: false,
+)
+@withCache
+abstract class NoMethodsSpecified {
+  factory NoMethodsSpecified() = _NoMethodsSpecified;
+
+  @Cached()
+  Future<int> cachedMethod(int x) async {
+    return 1;
+  }
+
+  @DeletesCache([])
+  Future<void> deleteCache() async {}
+}
+
+@ShouldThrow(
+  "[ERROR] invalidTarget is not a valid target for deleteCache",
+  element: false,
+)
+@withCache
+abstract class InvalidTarget {
+  factory InvalidTarget() = _InvalidTarget;
+
+  @Cached()
+  Future<int> cachedMethod(int x) async {
+    return 1;
+  }
+
+  Future<int> invalidTarget(int x) async {
+    return 1;
+  }
+
+  @DeletesCache(['invalidTarget'])
+  Future<void> deleteCache() async {}
+}
+
+@ShouldThrow(
+  "[ERROR] `deleteCache` cant be an abstract method",
+  element: false,
+)
+@withCache
+abstract class CantBeAbstract {
+  factory CantBeAbstract() = _CantBeAbstract;
+
+  @Cached()
+  Future<int> cachedMethod(int x) async {
+    return 1;
+  }
+
+  @DeletesCache(['cachedMethod'])
+  Future<void> deleteCache();
+}
+
+@ShouldGenerate(
+  r'''
+abstract class _$ValidNoTtl {}
+
+class _ValidNoTtl with ValidNoTtl implements _$ValidNoTtl {
+  _ValidNoTtl();
+
+  final _getSthDataCached = <String, String?>{};
+
+  @override
+  Future<String?> getSthData(String id) async {
+    final cachedValue = _getSthDataCached["${id.hashCode}"];
+    if (cachedValue == null) {
+      final String? toReturn;
+      try {
+        final result = super.getSthData(id);
+
+        toReturn = await result;
+      } catch (_) {
+        rethrow;
+      } finally {}
+
+      _getSthDataCached["${id.hashCode}"] = toReturn;
+
+      return toReturn;
+    } else {
+      return cachedValue;
+    }
+  }
+
+  @override
+  Future<String> addToData(String value) async {
+    final result = await super.addToData(value);
+
+    _getSthDataCached.clear();
+
+    return result;
+  }
+}
+''',
+)
+@withCache
+abstract class ValidNoTtl {
+  factory ValidNoTtl() = _ValidNoTtl;
+
+  @Cached()
+  Future<String?> getSthData(String id) async {
+    return '';
+  }
+
+  @DeletesCache(['getSthData'])
+  Future<String> addToData(String value) async {
+    return '';
+  }
+}
+
+@ShouldGenerate(
+  r'''
+abstract class _$ValidTtl {}
+
+class _ValidTtl with ValidTtl implements _$ValidTtl {
+  _ValidTtl();
+
+  final _getSthDataCached = <String, String?>{};
+
+  final _getSthDataTtl = <String, DateTime>{};
+
+  @override
+  Future<String?> getSthData(String id) async {
+    final now = DateTime.now();
+    final currentTtl = _getSthDataTtl["${id.hashCode}"];
+
+    if (currentTtl != null && currentTtl.isBefore(now)) {
+      _getSthDataTtl.remove("${id.hashCode}");
+      _getSthDataCached.remove("${id.hashCode}");
+    }
+
+    final cachedValue = _getSthDataCached["${id.hashCode}"];
+    if (cachedValue == null) {
+      final String? toReturn;
+      try {
+        final result = super.getSthData(id);
+
+        toReturn = await result;
+      } catch (_) {
+        rethrow;
+      } finally {}
+
+      _getSthDataCached["${id.hashCode}"] = toReturn;
+
+      _getSthDataTtl["${id.hashCode}"] =
+          DateTime.now().add(const Duration(seconds: 60));
+
+      return toReturn;
+    } else {
+      return cachedValue;
+    }
+  }
+
+  @override
+  Future<String> addToData(String value) async {
+    final result = await super.addToData(value);
+
+    _getSthDataCached.clear();
+    _getSthDataTtl.clear();
+
+    return result;
+  }
+}
+''',
+)
+@withCache
+abstract class ValidTtl {
+  factory ValidTtl() = _ValidTtl;
+
+  @Cached(ttl: 60)
+  Future<String?> getSthData(String id) async {
+    return '';
+  }
+
+  @DeletesCache(['getSthData'])
+  Future<String> addToData(String value) async {
+    return '';
+  }
+}
+
+@ShouldGenerate(
+  r'''
+abstract class _$ValidStreamed {}
+
+class _ValidStreamed with ValidStreamed implements _$ValidStreamed {
+  _ValidStreamed();
+
+  final _getSthDataCached = <String, String?>{};
+
+  static final _getSthDataCacheStreamController = StreamController<
+      MapEntry<StreamEventIdentifier<_ValidStreamed>, String?>>.broadcast();
+
+  @override
+  Future<String?> getSthData(String id) async {
+    final cachedValue = _getSthDataCached["${id.hashCode}"];
+    if (cachedValue == null) {
+      final String? toReturn;
+      try {
+        final result = super.getSthData(id);
+
+        toReturn = await result;
+      } catch (_) {
+        rethrow;
+      } finally {}
+
+      _getSthDataCached["${id.hashCode}"] = toReturn;
+
+      _getSthDataCacheStreamController.sink.add(MapEntry(
+        StreamEventIdentifier(
+          instance: this,
+          paramsKey: "${id.hashCode}",
+        ),
+        toReturn,
+      ));
+
+      return toReturn;
+    } else {
+      return cachedValue;
+    }
+  }
+
+  @override
+  Stream<String?> cachedStream(String id) async* {
+    final paramsKey = "${id.hashCode}";
+    final streamController = _getSthDataCacheStreamController;
+    final stream = streamController.stream
+        .where((event) => event.key.instance == this)
+        .where((event) =>
+            event.key.paramsKey == null || event.key.paramsKey == paramsKey)
+        .map((event) => event.value);
+
+    yield* stream;
+  }
+
+  @override
+  Future<String> addToData(String value) async {
+    final result = await super.addToData(value);
+
+    _getSthDataCached.clear();
+    _getSthDataCacheStreamController.sink.add(MapEntry(
+      StreamEventIdentifier(
+        instance: this,
+      ),
+      null,
+    ));
+
+    return result;
+  }
+}
+''',
+)
+@withCache
+abstract class ValidStreamed {
+  factory ValidStreamed() = _ValidStreamed;
+
+  @Cached()
+  Future<String?> getSthData(String id) async {
+    return '';
+  }
+
+  @StreamedCache(methodName: "getSthData")
+  Stream<String?> cachedStream(String id);
+
+  @DeletesCache(['getSthData'])
+  Future<String> addToData(String value) async {
+    return '';
+  }
+}
+
+@ShouldGenerate(
+  r'''
+abstract class _$ValidTwoMethods {}
+
+class _ValidTwoMethods with ValidTwoMethods implements _$ValidTwoMethods {
+  _ValidTwoMethods();
+
+  final _getSthDataCached = <String, String?>{};
+  final _getSthDataNoTtlCached = <String, String>{};
+
+  final _getSthDataTtl = <String, DateTime>{};
+
+  @override
+  Future<String?> getSthData(String id) async {
+    final now = DateTime.now();
+    final currentTtl = _getSthDataTtl["${id.hashCode}"];
+
+    if (currentTtl != null && currentTtl.isBefore(now)) {
+      _getSthDataTtl.remove("${id.hashCode}");
+      _getSthDataCached.remove("${id.hashCode}");
+    }
+
+    final cachedValue = _getSthDataCached["${id.hashCode}"];
+    if (cachedValue == null) {
+      final String? toReturn;
+      try {
+        final result = super.getSthData(id);
+
+        toReturn = await result;
+      } catch (_) {
+        rethrow;
+      } finally {}
+
+      _getSthDataCached["${id.hashCode}"] = toReturn;
+
+      _getSthDataTtl["${id.hashCode}"] =
+          DateTime.now().add(const Duration(seconds: 60));
+
+      return toReturn;
+    } else {
+      return cachedValue;
+    }
+  }
+
+  @override
+  Future<String> getSthDataNoTtl(String id) async {
+    final cachedValue = _getSthDataNoTtlCached["${id.hashCode}"];
+    if (cachedValue == null) {
+      final String toReturn;
+      try {
+        final result = super.getSthDataNoTtl(id);
+
+        toReturn = await result;
+      } catch (_) {
+        rethrow;
+      } finally {}
+
+      _getSthDataNoTtlCached["${id.hashCode}"] = toReturn;
+
+      return toReturn;
+    } else {
+      return cachedValue;
+    }
+  }
+
+  @override
+  Future<String> addToData(String value) async {
+    final result = await super.addToData(value);
+
+    _getSthDataCached.clear();
+    _getSthDataNoTtlCached.clear();
+    _getSthDataTtl.clear();
+
+    return result;
+  }
+}
+''',
+)
+@withCache
+abstract class ValidTwoMethods {
+  factory ValidTwoMethods() = ValidTwoMethods;
+
+  @Cached(ttl: 60)
+  Future<String?> getSthData(String id) async {
+    return '';
+  }
+
+  @Cached()
+  Future<String> getSthDataNoTtl(String id) {
+    return Future.delayed(
+      const Duration(milliseconds: 500),
+      () => '',
+    );
+  }
+
+  @DeletesCache(['getSthData', 'getSthDataNoTtl'])
+  Future<String> addToData(String value) async {
+    return '';
+  }
+}
+
+@ShouldGenerate(
+  r'''
+abstract class _$ValidSync {}
+
+class _ValidSync with ValidSync implements _$ValidSync {
+  _ValidSync();
+
+  final _getSthDataCached = <String, String>{};
+
+  @override
+  String getSthData(String id) {
+    final cachedValue = _getSthDataCached["${id.hashCode}"];
+    if (cachedValue == null) {
+      final String toReturn;
+      try {
+        final result = super.getSthData(id);
+
+        toReturn = result;
+      } catch (_) {
+        rethrow;
+      } finally {}
+
+      _getSthDataCached["${id.hashCode}"] = toReturn;
+
+      return toReturn;
+    } else {
+      return cachedValue;
+    }
+  }
+
+  @override
+  String addToData(String value) {
+    final result = super.addToData(value);
+
+    _getSthDataCached.clear();
+
+    return result;
+  }
+}
+''',
+)
+@withCache
+abstract class ValidSync {
+  factory ValidSync() = ValidSync;
+
+  @Cached()
+  String getSthData(String id) {
+    return '';
+  }
+
+  @DeletesCache(['getSthData'])
+  String addToData(String value) {
+    return '';
+  }
+}

--- a/packages/cached/test/integration/async_integration_test.dart
+++ b/packages/cached/test/integration/async_integration_test.dart
@@ -151,5 +151,80 @@ void main() {
 
       expect(cachedValue, equals(secondCachedValue));
     });
+
+    test(
+        'deletes cache method should clear async cache if future returns value',
+        () async {
+      final cachedClass = AsynchronousCached(_dataProvider);
+      final cachedValue = await cachedClass.asyncCachedValue();
+      await cachedClass.deleteAsyncCachedValue();
+      final secondCachedValue = await cachedClass.asyncCachedValue();
+
+      expect(cachedValue != secondCachedValue, true);
+    });
+
+    test(
+        'deletes cache method should not clear async cache if future fails to return value',
+        () async {
+      final cachedClass = AsynchronousCached(_dataProvider);
+      final cachedValue = await cachedClass.asyncCachedValue();
+      try {
+        await cachedClass.deleteAsyncCachedValueFail();
+      } catch (e) {
+        //
+      }
+
+      final secondCachedValue = await cachedClass.asyncCachedValue();
+
+      expect(cachedValue != secondCachedValue, false);
+    });
+
+    test('deletes cache method should clear sync cache if future returns value',
+        () async {
+      final cachedClass = AsynchronousCached(_dataProvider);
+      final cachedValue = await cachedClass.syncCachedValue();
+      await cachedClass.deleteCachedValue();
+      final secondCachedValue = await cachedClass.syncCachedValue();
+
+      expect(cachedValue != secondCachedValue, true);
+    });
+
+    test(
+        'deletes cache method should not clear sync cache if future fails to return value',
+        () async {
+      final cachedClass = AsynchronousCached(_dataProvider);
+      final cachedValue = await cachedClass.syncCachedValue();
+      try {
+        await cachedClass.deleteCachedValueFail();
+      } catch (e) {
+        //
+      }
+
+      final secondCachedValue = await cachedClass.syncCachedValue();
+
+      expect(cachedValue != secondCachedValue, false);
+    });
+
+    test(
+        'deletes cache method should clear async cache with ttl if future returns value',
+        () async {
+      final cachedClass = AsynchronousCached(_dataProvider);
+      final cachedValue = await cachedClass.asyncCachedValueWithTTl();
+      await cachedClass.deleteAsyncTTLCachedValue();
+      final secondCachedValue = await cachedClass.asyncCachedValueWithTTl();
+
+      expect(cachedValue != secondCachedValue, true);
+    });
+
+    test(
+        'deletes cache method should clear sync cache with ttl if future returns value',
+        () async {
+      final cachedClass = AsynchronousCached(_dataProvider);
+      final cachedValue = await cachedClass.syncCachedValueWithTTl();
+      await cachedClass.deleteTTLCachedValue();
+      final secondCachedValue = await cachedClass.syncCachedValueWithTTl();
+
+      expect(cachedValue != secondCachedValue, true);
+    });
   });
 }

--- a/packages/cached/test/integration/asynchronous/cached_test_asynchronous.dart
+++ b/packages/cached/test/integration/asynchronous/cached_test_asynchronous.dart
@@ -75,4 +75,48 @@ abstract class AsynchronousCached implements _$AsynchronousCached {
   void resetCounter() => _counter = 0;
 
   int counter() => _counter;
+
+  @DeletesCache(['asyncCachedValue'])
+  Future<void> deleteAsyncCachedValue() async {
+    await Future.delayed(const Duration(milliseconds: 100));
+  }
+
+  @DeletesCache(['asyncCachedValue'])
+  Future<void> deleteAsyncCachedValueFail() async {
+    await Future.delayed(const Duration(milliseconds: 100));
+    throw Exception();
+  }
+
+  @DeletesCache(['asyncCachedValueWithTTl'])
+  Future<void> deleteAsyncTTLCachedValue() async {
+    await Future.delayed(const Duration(milliseconds: 100));
+  }
+
+  @DeletesCache(['asyncCachedValueWithTTl'])
+  Future<void> deleteAsyncTTLCachedValueFail() async {
+    await Future.delayed(const Duration(milliseconds: 100));
+    throw Exception();
+  }
+
+  @DeletesCache(['syncCachedValue'])
+  Future<void> deleteCachedValue() async {
+    await Future.delayed(const Duration(milliseconds: 100));
+  }
+
+  @DeletesCache(['syncCachedValue'])
+  Future<void> deleteCachedValueFail() async {
+    await Future.delayed(const Duration(milliseconds: 100));
+    throw Exception();
+  }
+
+  @DeletesCache(['syncCachedValueWithTTl'])
+  Future<void> deleteTTLCachedValue() async {
+    await Future.delayed(const Duration(milliseconds: 100));
+  }
+
+  @DeletesCache(['syncCachedValueWithTTl'])
+  Future<void> deleteTTLCachedValueFail() async {
+    await Future.delayed(const Duration(milliseconds: 100));
+    throw Exception();
+  }
 }

--- a/packages/cached/test/integration/simple/cached_test_simple.dart
+++ b/packages/cached/test/integration/simple/cached_test_simple.dart
@@ -94,6 +94,14 @@ abstract class SimpleCached implements _$SimpleCached {
 
   @clearAllCached
   void clearAll();
+
+  @DeletesCache(['cachedValue'])
+  void deleteCachedValue() {}
+
+  @DeletesCache(['cachedValue'])
+  void deleteCachedValueFail() {
+    throw Exception();
+  }
 }
 
 String _cachedKeyGenerator(dynamic value) => value.toString();

--- a/packages/cached/test/integration/simple_integration_test.dart
+++ b/packages/cached/test/integration/simple_integration_test.dart
@@ -202,5 +202,32 @@ void main() {
         expect(cachedValue, equals(secondCachedValue));
       }
     });
+
+    test(
+        'deletes cache method should clear cache if function returns with value',
+        () {
+      final cachedClass = SimpleCached(_dataProvider);
+      final cachedValue = cachedClass.cachedValue();
+      cachedClass.deleteCachedValue();
+      final secondCachedValue = cachedClass.cachedValue();
+
+      expect(cachedValue != secondCachedValue, true);
+    });
+
+    test(
+        'deletes cache method should not clear cache if function returns with error',
+        () {
+      final cachedClass = SimpleCached(_dataProvider);
+      final cachedValue = cachedClass.cachedValue();
+      try {
+        cachedClass.deleteCachedValueFail();
+      } catch (e) {
+        //
+      }
+
+      final secondCachedValue = cachedClass.cachedValue();
+
+      expect(cachedValue != secondCachedValue, false);
+    });
   });
 }

--- a/packages/cached/test/integration/static/cached_test_static.dart
+++ b/packages/cached/test/integration/static/cached_test_static.dart
@@ -21,4 +21,12 @@ abstract class StaticCached implements _$StaticCached {
 
   @clearAllCached
   void clearCache();
+
+  @DeletesCache(['cachedValue'])
+  void deleteCachedValue() {}
+
+  @DeletesCache(['cachedValue'])
+  void deleteCachedValueFail() {
+    throw Exception();
+  }
 }

--- a/packages/cached/test/integration/static_integration_test.dart
+++ b/packages/cached/test/integration/static_integration_test.dart
@@ -46,5 +46,32 @@ void main() {
 
       expect(cachedValue, equals(cachedValueFromAnotherInstance));
     });
+
+    test(
+        'deletes cache method should clear cache if function returns with value',
+        () {
+      final cachedClass = StaticCached(_dataProvider);
+      final cachedValue = cachedClass.cachedValue();
+      cachedClass.deleteCachedValue();
+      final secondCachedValue = cachedClass.cachedValue();
+
+      expect(cachedValue != secondCachedValue, true);
+    });
+
+    test(
+        'deletes cache method should not clear cache if function returns with error',
+        () {
+      final cachedClass = StaticCached(_dataProvider);
+      final cachedValue = cachedClass.cachedValue();
+      try {
+        cachedClass.deleteCachedValueFail();
+      } catch (e) {
+        //
+      }
+
+      final secondCachedValue = cachedClass.cachedValue();
+
+      expect(cachedValue != secondCachedValue, false);
+    });
   });
 }

--- a/packages/cached_annotation/lib/cached_annotation.dart
+++ b/packages/cached_annotation/lib/cached_annotation.dart
@@ -7,6 +7,7 @@ export 'src/cache_peek.dart';
 export 'src/cached.dart';
 export 'src/clear_all_cached.dart';
 export 'src/clear_cached.dart';
+export 'src/deletes_cache.dart';
 export 'src/ignore.dart';
 export 'src/ignore_cache.dart';
 export 'src/streamed_cache.dart';

--- a/packages/cached_annotation/lib/src/deletes_cache.dart
+++ b/packages/cached_annotation/lib/src/deletes_cache.dart
@@ -1,0 +1,50 @@
+import 'package:meta/meta_meta.dart';
+
+/// {@template cached.deletes_cache}
+/// #### DeletesCache
+///
+/// Annotation for for 'Cached package'.
+///
+/// Throws an [InvalidGenerationSourceError]
+/// * if method with @cached annotation doesn't exist
+/// * if no target method names are specified
+/// * if specified target methods are invalid
+/// * if annotated class is abstract
+///
+/// ### Example
+///
+/// If there's a method with @Cached() annotation
+///
+/// ```dart
+/// @Cached()
+/// Future<SomeResponseType> getSthData() {
+///   return dataSource.getData();
+/// }
+/// ```
+///
+/// If you have a method that alters the cached data, then to clear the cache
+/// of affected methods on successful operation just place the '@DeletesCache'
+/// annotation before method declaration, and specify methods that are
+/// affected by the use of this method in method arguments
+///
+/// ```dart
+/// @DeletesCache(['getSthData'])
+/// Future<SomeResponseType> performOperation() {
+///   ...
+///   return data;
+/// }
+/// ```
+///
+/// The cache of the specified methods will be cleared if the method annotated
+/// with @DeletesCache completes without throwing an error,
+/// but if an error occurs, the cache is not deleted and the error is rethrown.
+///
+/// {@endtemplate}
+@Target({TargetKind.method})
+class DeletesCache {
+  /// {@macro cached.deletes_cache}
+  const DeletesCache(this.methodNames);
+
+  /// Name of methods whose cache is altered by this method
+  final List<String> methodNames;
+}


### PR DESCRIPTION
Added @DeletesCache annotation which gives user the ability to specify methods that affect cached methods, and delete the cached data of affected methods.

If you have class with cache:
![No ttl cache class](https://user-images.githubusercontent.com/43029034/201102864-24fcceee-8ce5-41e3-b9d8-0d87a4a0e66e.png)

then cached will generate:
![generated](https://user-images.githubusercontent.com/43029034/201103051-a6f13474-66bf-4e5b-94ec-1b654ae69b68.png)

Generated method will delete cached data if the call to super method will return result.

Generated method will also clear streamed cache, and ttl of cached data if it is available
![ttl no ttl streamed](https://user-images.githubusercontent.com/43029034/201105117-89dc8345-1dab-4e57-8d9c-a623e83ef942.png)

![generated ttl no ttl streamed clear](https://user-images.githubusercontent.com/43029034/201105244-d9737fce-aa39-47d6-891c-cc1967434b7d.png)
