### PR TITLE
modified logo size, removed named arguments from cache_key, cache_pee…

### DIFF
--- a/packages/cached/README.md
+++ b/packages/cached/README.md
@@ -12,7 +12,7 @@ and the Flutter guide for
 -->
 <div align="center">
 <br /><br />
-<img width="400" src="https://github.com/Iteo/cached/raw/master/packages/cached/cached_sygnet.png">
+<img width="128" src="https://github.com/Iteo/cached/raw/master/packages/cached/cached_sygnet.png">
 <br /><br />
 
 [![Test status](https://github.com/Iteo/cached/workflows/Build/badge.svg)](https://github.com/Iteo/cached/actions/workflows/build.yml)
@@ -173,7 +173,7 @@ abstract class Gen implements _$Gen {
 
 ### Cached
 
-Method decorator that flag it as needing to be processed by `Cached` code generator.
+Method/Getter decorator that flag it as needing to be processed by `Cached` code generator.
 
 There are 3 possible additional parameters:
 
@@ -192,6 +192,13 @@ There are 3 possible additional parameters:
   limit: 100,
 )
 Future<int> getInt(String param) {
+  return Future.value(1);
+}
+```
+
+```dart
+@cached
+Future<int> get getter {
   return Future.value(1);
 }
 ```
@@ -247,7 +254,7 @@ Example use:
 
 ```dart
 @cached
-Future<int> getInt(@CacheKey(cacheKeyGenerator: exampleCacheFunction) int test) async {
+Future<int> getInt(@CacheKey(exampleCacheFunction) int test) async {
   await Future.delayed(Duration(milliseconds: 20));
   return test;
 }
@@ -399,7 +406,7 @@ Future<SomeResponseType> getUserData() {
 to generate peek cache method we can write:
 
 ```dart
-@CachePeek(methodName: "getUserData")
+@CachePeek("getUserData")
 SomeResponseType? peekUserDataCache();
 ```
 

--- a/packages/cached/example/bin/gen.dart
+++ b/packages/cached/example/bin/gen.dart
@@ -56,6 +56,10 @@ abstract class Gen implements _$Gen {
     return get(Uri.parse(_url));
   }
 
+  /// @Cached annotation also works with getters
+  @Cached(syncWrite: true, ttl: 30, limit: 10)
+  Future<Response> get getDataWithCachedGetter async => get(Uri.parse(_url));
+
   /// Method for measure example, you can go to example.dart file
   /// and run main method, so you can check how great [Checked] package is it.
   Future<Response> getDataWithoutCached() {
@@ -67,7 +71,7 @@ abstract class Gen implements _$Gen {
   Stream<Response> getDataCacheStream();
 
   /// Method for getting data of cache method
-  @CachePeek(methodName: "getDataWithCached")
+  @CachePeek("getDataWithCached")
   Response? peekDataCache();
 
   /// Method annotated with this annotation can be used to clear result

--- a/packages/cached/example/pubspec.lock
+++ b/packages/cached/example/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "40.0.0"
+    version: "47.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.0"
+    version: "4.7.0"
   args:
     dependency: transitive
     description:
@@ -28,21 +28,21 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.9.0"
+    version: "2.10.0"
   build:
     dependency: transitive
     description:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.0"
+    version: "2.3.1"
   build_config:
     dependency: transitive
     description:
       name: build_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.1"
   build_daemon:
     dependency: transitive
     description:
@@ -56,21 +56,21 @@ packages:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.0.10"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.10"
+    version: "2.3.2"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.2.3"
+    version: "7.2.7"
   built_collection:
     dependency: transitive
     description:
@@ -84,7 +84,7 @@ packages:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.3.0"
+    version: "8.4.2"
   cached:
     dependency: "direct dev"
     description:
@@ -99,13 +99,6 @@ packages:
       relative: true
     source: path
     version: "1.3.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -119,21 +112,21 @@ packages:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.0"
+    version: "4.3.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   convert:
     dependency: transitive
     description:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.1"
   crypto:
     dependency: transitive
     description:
@@ -147,14 +140,14 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.3"
+    version: "2.2.4"
   file:
     dependency: transitive
     description:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.2"
+    version: "6.1.4"
   fixnum:
     dependency: transitive
     description:
@@ -168,42 +161,42 @@ packages:
       name: frontend_server_client
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "3.1.0"
   glob:
     dependency: transitive
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.1.1"
   graphs:
     dependency: transitive
     description:
       name: graphs
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   http:
     dependency: "direct main"
     description:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.4"
+    version: "0.13.5"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.0"
+    version: "3.2.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "4.0.2"
   io:
     dependency: transitive
     description:
@@ -217,14 +210,14 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.5"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.5.0"
+    version: "4.7.0"
   lints:
     dependency: "direct dev"
     description:
@@ -238,14 +231,14 @@ packages:
       name: logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.1.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.13"
   meta:
     dependency: transitive
     description:
@@ -266,105 +259,105 @@ packages:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.1.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   pool:
     dependency: transitive
     description:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.0"
+    version: "1.5.1"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.3"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   shelf:
     dependency: transitive
     description:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.3"
   source_gen:
     dependency: transitive
     description:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.2"
+    version: "1.2.6"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   source_span:
     dependency: transitive
     description:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   stream_transform:
     dependency: transitive
     description:
       name: stream_transform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   timing:
     dependency: transitive
     description:
@@ -385,7 +378,7 @@ packages:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   web_socket_channel:
     dependency: transitive
     description:
@@ -401,4 +394,4 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.16.1 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"

--- a/packages/cached/lib/src/models/cache_peek_method.dart
+++ b/packages/cached/lib/src/models/cache_peek_method.dart
@@ -23,7 +23,7 @@ class CachePeekMethod {
 
   factory CachePeekMethod.fromElement(
     MethodElement element,
-    List<MethodElement> classMethods,
+    List<ExecutableElement> classMethods,
     Config config,
   ) {
     final annotation = getAnnotation(element);

--- a/packages/cached/lib/src/models/cached_function.dart
+++ b/packages/cached/lib/src/models/cached_function.dart
@@ -1,0 +1,35 @@
+import 'package:analyzer/dart/constant/value.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:cached/src/utils/asserts.dart';
+import 'package:cached_annotation/cached_annotation.dart';
+import 'package:source_gen/source_gen.dart';
+
+abstract class CachedFunction {
+  CachedFunction({
+    required this.name,
+    required this.syncWrite,
+    required this.isAsync,
+    required this.isGenerator,
+    required this.returnType,
+    this.limit,
+    this.ttl,
+  });
+
+  final String name;
+  final bool syncWrite;
+  final String returnType;
+  final bool isGenerator;
+  final bool isAsync;
+  final int? limit;
+  final int? ttl;
+
+  static void assertIsValid(ExecutableElement element) {
+    assertMethodNotVoid(element);
+    assertMethodIsNotAbstract(element);
+  }
+
+  static DartObject? getAnnotation(ExecutableElement element) {
+    const methodAnnotationChecker = TypeChecker.fromRuntime(Cached);
+    return methodAnnotationChecker.firstAnnotationOf(element);
+  }
+}

--- a/packages/cached/lib/src/models/cached_getter.dart
+++ b/packages/cached/lib/src/models/cached_getter.dart
@@ -2,16 +2,13 @@ import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:cached/src/config.dart';
 import 'package:cached/src/models/cached_function.dart';
-import 'package:cached/src/models/param.dart';
-import 'package:cached/src/utils/asserts.dart';
 import 'package:cached_annotation/cached_annotation.dart';
 import 'package:source_gen/source_gen.dart';
 
 const _defaultSyncWriteValue = false;
 
-class CachedMethod extends CachedFunction {
-  CachedMethod({
-    required this.params,
+class CachedGetter extends CachedFunction {
+  CachedGetter({
     required String name,
     required bool syncWrite,
     required String returnType,
@@ -29,9 +26,10 @@ class CachedMethod extends CachedFunction {
           ttl: ttl,
         );
 
-  final Iterable<Param> params;
-
-  factory CachedMethod.fromElement(MethodElement element, Config config) {
+  factory CachedGetter.fromElement(
+    PropertyAccessorElement element,
+    Config config,
+  ) {
     CachedFunction.assertIsValid(element);
 
     final annotation = getAnnotation(element);
@@ -57,7 +55,7 @@ class CachedMethod extends CachedFunction {
       }
     }
 
-    final method = CachedMethod(
+    final method = CachedGetter(
       name: element.name,
       syncWrite: syncWrite ?? config.syncWrite ?? _defaultSyncWriteValue,
       limit: limit ?? config.limit,
@@ -65,14 +63,12 @@ class CachedMethod extends CachedFunction {
       returnType: element.returnType.getDisplayString(withNullability: true),
       isAsync: element.isAsynchronous,
       isGenerator: element.isGenerator,
-      params: element.parameters.map((e) => Param.fromElement(e, config)),
     );
-    assertOneIgnoreCacheParam(method);
 
     return method;
   }
 
-  static DartObject? getAnnotation(MethodElement element) {
+  static DartObject? getAnnotation(PropertyAccessorElement element) {
     const methodAnnotationChecker = TypeChecker.fromRuntime(Cached);
     return methodAnnotationChecker.firstAnnotationOf(element);
   }

--- a/packages/cached/lib/src/models/param.dart
+++ b/packages/cached/lib/src/models/param.dart
@@ -14,9 +14,9 @@ class IgnoreCacheAnnotation {
 }
 
 class CacheKeyAnnotation {
-  const CacheKeyAnnotation({
-    required this.cacheFunctionCall,
-  });
+  const CacheKeyAnnotation(
+    this.cacheFunctionCall,
+  );
 
   final String cacheFunctionCall;
 
@@ -111,7 +111,7 @@ class Param {
         }
 
         cacheKeyAnnotationData = CacheKeyAnnotation(
-          cacheFunctionCall: cacheKeyFunc.name,
+          cacheKeyFunc.name,
         );
       }
     }

--- a/packages/cached/lib/src/models/streamed_cache_method.dart
+++ b/packages/cached/lib/src/models/streamed_cache_method.dart
@@ -27,7 +27,7 @@ class StreamedCacheMethod {
 
   factory StreamedCacheMethod.fromElement(
     MethodElement element,
-    List<MethodElement> classMethods,
+    List<ExecutableElement> classMethods,
     Config config,
   ) {
     final annotation = getAnnotation(element);
@@ -111,7 +111,7 @@ class StreamedCacheMethod {
     );
   }
 
-  static DartObject? getAnnotation(MethodElement element) {
+  static DartObject? getAnnotation(ExecutableElement element) {
     const methodAnnotationChecker = TypeChecker.fromRuntime(StreamedCache);
     return methodAnnotationChecker.firstAnnotationOf(element);
   }

--- a/packages/cached/lib/src/templates/cached_function_template.dart
+++ b/packages/cached/lib/src/templates/cached_function_template.dart
@@ -1,0 +1,158 @@
+import 'package:cached/src/models/cached_function.dart';
+import 'package:cached/src/utils/utils.dart';
+
+abstract class CachedFunctionTemplate {
+  CachedFunctionTemplate(
+    this.function, {
+    required this.useStaticCache,
+    required this.isCacheStreamed,
+  });
+
+  final CachedFunction function;
+  final bool useStaticCache;
+  final bool isCacheStreamed;
+
+  String generateDefinition();
+
+  String generateUsage();
+
+  String generateOnCatch();
+
+  String generateAdditionalCacheCondition() => "";
+
+  String get paramsKey;
+
+  String generateSyncMap() {
+    if (!function.syncWrite) {
+      return '';
+    }
+
+    return '${_getStaticModifier()} final $_syncMapName = <String, Future<$_syncReturnType>>{};';
+  }
+
+  String generateCacheMap() {
+    return '${_getStaticModifier()} final $_cacheMapName = <String, $_syncReturnType>{};';
+  }
+
+  String generateTtlMap() {
+    if (function.ttl == null) {
+      return '';
+    }
+
+    return '${_getStaticModifier()} final $_ttlMapName = <String, DateTime>{};';
+  }
+
+  String generate() {
+    final syncModifier =
+        function.isGenerator && !function.isAsync ? 'sync' : '';
+    final asyncModifier = _returnsFuture || function.isAsync ? 'async' : '';
+    final generatorModifier = function.isGenerator ? '*' : '';
+    final returnKeyword = function.isGenerator ? 'yield*' : 'return';
+    final awaitIfNeeded = _returnsFuture ? 'await' : '';
+
+    return '''
+@override
+${function.returnType} ${generateDefinition()} $syncModifier$asyncModifier$generatorModifier {
+  ${_generateRemoveTtlLogic()}
+  final cachedValue = $_cacheMapName["$paramsKey"];
+  if (cachedValue == null ${generateAdditionalCacheCondition()}) {
+    ${_generateGetSyncedLogic()}
+
+    final $_syncReturnType toReturn;
+    try {
+      final result = super.${generateUsage()};
+      ${function.syncWrite && _returnsFuture ? "$_syncMapName['$paramsKey'] = result;" : ""}
+      toReturn = $awaitIfNeeded result;
+    } catch(_) {
+      ${generateOnCatch()}
+    } finally {
+      ${function.syncWrite && _returnsFuture ? "$_syncMapName.remove('$paramsKey');" : ""}
+    }
+
+    $_cacheMapName["$paramsKey"] = toReturn;
+
+    ${_generateStreamCall()}
+
+    ${_generateLimitLogic()}
+    ${_generateAddTtlLogic()}
+    $returnKeyword toReturn;
+  } else {
+    $returnKeyword cachedValue;
+  }
+}
+
+''';
+  }
+
+  String _getStaticModifier() {
+    return useStaticCache ? 'static' : '';
+  }
+
+  String _generateGetSyncedLogic() {
+    if (!function.syncWrite || !_returnsFuture) return '';
+
+    return '''
+final cachedFuture = $_syncMapName["$paramsKey"];
+
+if (cachedFuture != null) {
+  return cachedFuture;
+}
+''';
+  }
+
+  String _generateRemoveTtlLogic() {
+    if (function.ttl == null) return '';
+
+    return '''
+final now = DateTime.now();
+final currentTtl = $_ttlMapName["$paramsKey"];
+
+if (currentTtl != null && currentTtl.isBefore(now)) {
+  $_ttlMapName.remove("$paramsKey");
+  $_cacheMapName.remove("$paramsKey");
+}
+''';
+  }
+
+  String _generateAddTtlLogic() {
+    if (function.ttl == null) return '';
+
+    return '''
+$_ttlMapName["$paramsKey"] = DateTime.now().add(const Duration(seconds: ${function.ttl}));
+''';
+  }
+
+  String get _cacheMapName => getCacheMapName(function.name);
+
+  String get _ttlMapName => getTtlMapName(function.name);
+
+  String get _syncMapName => '_${function.name}Sync';
+
+  bool get _returnsFuture => isFuture(function.returnType);
+
+  String get _syncReturnType => syncReturnType(function.returnType);
+
+  String _generateLimitLogic() {
+    if (function.limit == null) return '';
+
+    return '''
+if ($_cacheMapName.length > ${function.limit}) {
+  $_cacheMapName.remove($_cacheMapName.entries.last.key);
+}
+''';
+  }
+
+  String _generateStreamCall() {
+    if (!isCacheStreamed) {
+      return '';
+    }
+    return '''
+          ${getCacheStreamControllerName(function.name)}.sink.add(MapEntry(StreamEventIdentifier(
+              ${useStaticCache ? '' : 'instance: this,'}
+              paramsKey: "$paramsKey",
+            ),
+            toReturn,
+          ));
+          ''';
+  }
+}

--- a/packages/cached/lib/src/templates/cached_getter_template.dart
+++ b/packages/cached/lib/src/templates/cached_getter_template.dart
@@ -1,0 +1,32 @@
+import 'package:cached/src/models/cached_getter.dart';
+import 'package:cached/src/templates/cached_function_template.dart';
+
+class CachedGetterTemplate extends CachedFunctionTemplate {
+  CachedGetterTemplate(
+    CachedGetter getter, {
+    required bool useStaticCache,
+    required bool isCacheStreamed,
+  }) : super(
+          getter,
+          useStaticCache: useStaticCache,
+          isCacheStreamed: isCacheStreamed,
+        );
+
+  @override
+  String get paramsKey => "";
+
+  @override
+  String generateDefinition() {
+    return "get ${function.name}";
+  }
+
+  @override
+  String generateUsage() {
+    return function.name;
+  }
+
+  @override
+  String generateOnCatch() {
+    return 'rethrow;';
+  }
+}

--- a/packages/cached/lib/src/templates/cached_method_template.dart
+++ b/packages/cached/lib/src/templates/cached_method_template.dart
@@ -1,162 +1,55 @@
 import 'package:cached/src/models/cached_method.dart';
+import 'package:cached/src/models/param.dart';
 import 'package:cached/src/templates/all_params_template.dart';
+import 'package:cached/src/templates/cached_function_template.dart';
 import 'package:cached/src/utils/utils.dart';
 import 'package:collection/collection.dart';
 
-class CachedMethodTemplate {
+class CachedMethodTemplate extends CachedFunctionTemplate {
   CachedMethodTemplate(
     this.method, {
-    required this.methods,
-    required this.useStaticCache,
-    required this.isCacheStreamed,
-  }) : paramsTemplate = AllParamsTemplate(method.params);
+    required bool useStaticCache,
+    required bool isCacheStreamed,
+  })  : paramsTemplate = AllParamsTemplate(method.params),
+        super(
+          method,
+          useStaticCache: useStaticCache,
+          isCacheStreamed: isCacheStreamed,
+        );
 
-  final CachedMethod method;
-  final Iterable<CachedMethod> methods;
   final AllParamsTemplate paramsTemplate;
-  final bool useStaticCache;
-  final bool isCacheStreamed;
+  final CachedMethod method;
 
-  String generateSyncMap() {
-    if (!method.syncWrite) {
-      return '';
-    }
+  Param? get ignoreCacheParam => method.params
+      .firstWhereOrNull((element) => element.ignoreCacheAnnotation != null);
 
-    return '${_getStaticModifier()} final $_syncMapName = <String, Future<$_syncReturnType>>{};';
+  @override
+  String get paramsKey => getParamKey(method.params);
+
+  @override
+  String generateDefinition() {
+    return "${function.name}(${paramsTemplate.generateParams()})";
   }
 
-  String generateCacheMap() {
-    return '${_getStaticModifier()} final $_cacheMapName = <String, $_syncReturnType>{};';
+  @override
+  String generateUsage() {
+    return "${function.name}(${paramsTemplate.generateParamsUsage()})";
   }
 
-  String generateTtlMap() {
-    if (method.ttl == null) {
-      return '';
-    }
-
-    return '${_getStaticModifier()} final $_ttlMapName = <String, DateTime>{};';
-  }
-
-  String generateMethod() {
-    final syncModifier = method.isGenerator && !method.isAsync ? 'sync' : '';
-    final asyncModifier = _returnsFuture || method.isAsync ? 'async' : '';
-    final generatorModifier = method.isGenerator ? '*' : '';
-    final returnKeyword = method.isGenerator ? 'yield*' : 'return';
-    final awaitIfNeeded = _returnsFuture ? 'await' : '';
-
-    final ignoreCacheParam = method.params
-        .firstWhereOrNull((element) => element.ignoreCacheAnnotation != null);
-    final useCacheOnError =
-        ignoreCacheParam?.ignoreCacheAnnotation?.useCacheOnError ?? false;
+  @override
+  String generateAdditionalCacheCondition() {
+    final ignoreCacheParam = this.ignoreCacheParam;
 
     final ignoreCacheCondition =
         ignoreCacheParam != null ? '|| ${ignoreCacheParam.name}' : '';
-    return '''
-@override
-${method.returnType} ${method.name}(${paramsTemplate.generateParams()}) $syncModifier$asyncModifier$generatorModifier {
-  ${_generateRemoveTtlLogic()}
-  final cachedValue = $_cacheMapName["$_paramsKey"];
-  if (cachedValue == null $ignoreCacheCondition) {
-    ${_generateGetSyncedLogic()}
 
-    final $_syncReturnType toReturn;
-    try {
-      final result = super.${method.name}(${paramsTemplate.generateParamsUsage()});
-      ${method.syncWrite && _returnsFuture ? "$_syncMapName['$_paramsKey'] = result;" : ""}
-      toReturn = $awaitIfNeeded result;
-    } catch(_) {
-      ${useCacheOnError ? "if (cachedValue != null) { return cachedValue; }" : ""}
-      rethrow;
-    } finally {
-      ${method.syncWrite && _returnsFuture ? "$_syncMapName.remove('$_paramsKey');" : ""}
-    }
-
-    $_cacheMapName["$_paramsKey"] = toReturn;
-
-    ${_generateStreamCall()}
-
-    ${_generateLimitLogic()}
-    ${_generateAddTtlLogic()}
-    $returnKeyword toReturn;
-  } else {
-    $returnKeyword cachedValue;
-  }
-}
-
-''';
+    return ignoreCacheCondition;
   }
 
-  String _getStaticModifier() {
-    return useStaticCache ? 'static' : '';
-  }
-
-  String _generateGetSyncedLogic() {
-    if (!method.syncWrite || !_returnsFuture) return '';
-
-    return '''
-final cachedFuture = $_syncMapName["$_paramsKey"];
-
-if (cachedFuture != null) {
-  return cachedFuture;
-}
-''';
-  }
-
-  String _generateRemoveTtlLogic() {
-    if (method.ttl == null) return '';
-
-    return '''
-final now = DateTime.now();
-final currentTtl = $_ttlMapName["$_paramsKey"];
-
-if (currentTtl != null && currentTtl.isBefore(now)) {
-  $_ttlMapName.remove("$_paramsKey");
-  $_cacheMapName.remove("$_paramsKey");
-}
-''';
-  }
-
-  String _generateAddTtlLogic() {
-    if (method.ttl == null) return '';
-
-    return '''
-$_ttlMapName["$_paramsKey"] = DateTime.now().add(const Duration(seconds: ${method.ttl}));
-''';
-  }
-
-  String get _paramsKey => getParamKey(method.params);
-
-  String get _cacheMapName => getCacheMapName(method.name);
-
-  String get _ttlMapName => getTtlMapName(method.name);
-
-  String get _syncMapName => '_${method.name}Sync';
-
-  bool get _returnsFuture => isFuture(method.returnType);
-
-  String get _syncReturnType => syncReturnType(method.returnType);
-
-  String _generateLimitLogic() {
-    if (method.limit == null) return '';
-
-    return '''
-if ($_cacheMapName.length > ${method.limit}) {
-  $_cacheMapName.remove($_cacheMapName.entries.last.key);
-}
-''';
-  }
-
-  String _generateStreamCall() {
-    if (!isCacheStreamed) {
-      return '';
-    }
-    return '''
-          ${getCacheStreamControllerName(method.name)}.sink.add(MapEntry(StreamEventIdentifier(
-              ${useStaticCache ? '' : 'instance: this,'}
-              paramsKey: "$_paramsKey",
-            ),
-            toReturn,
-          ));
-          ''';
+  @override
+  String generateOnCatch() {
+    final useCacheOnError =
+        ignoreCacheParam?.ignoreCacheAnnotation?.useCacheOnError ?? false;
+    return '${useCacheOnError ? "if (cachedValue != null) { return cachedValue;\n }" : ""}rethrow;';
   }
 }

--- a/packages/cached/lib/src/templates/class_template.dart
+++ b/packages/cached/lib/src/templates/class_template.dart
@@ -1,6 +1,7 @@
 import 'package:cached/src/models/class_with_cache.dart';
 import 'package:cached/src/templates/all_params_template.dart';
 import 'package:cached/src/templates/cache_peek_method_template.dart';
+import 'package:cached/src/templates/cached_getter_template.dart';
 import 'package:cached/src/templates/cached_method_template.dart';
 import 'package:cached/src/templates/clear_all_cached_method_template.dart';
 import 'package:cached/src/templates/clear_cached_method_template.dart';
@@ -19,7 +20,15 @@ class ClassTemplate {
     final methodTemplates = classMethods.map(
       (e) => CachedMethodTemplate(
         e,
-        methods: classMethods,
+        useStaticCache: classWithCache.useStaticCache,
+        isCacheStreamed: classWithCache.streamedCacheMethods
+            .any((s) => s.targetMethodName == e.name),
+      ),
+    );
+
+    final getterTemplates = classWithCache.getters.map(
+      (e) => CachedGetterTemplate(
+        e,
         useStaticCache: classWithCache.useStaticCache,
         isCacheStreamed: classWithCache.streamedCacheMethods
             .any((s) => s.targetMethodName == e.name),
@@ -48,6 +57,7 @@ class ClassTemplate {
     final clearAllMethodTemplate = ClearAllCachedMethodTemplate(
       method: classWithCache.clearAllMethod,
       cachedMethods: classMethods,
+      cachedGetters: classWithCache.getters,
       streamedCacheMethods: classWithCache.streamedCacheMethods,
     );
 
@@ -80,14 +90,18 @@ class _${classWithCache.name} with ${classWithCache.name} implements _\$${classW
   ${constructorParamTemplates.generateFields(addOverrideAnnotation: true)}
 
   ${methodTemplates.map((e) => e.generateSyncMap()).join('\n')}
+  ${getterTemplates.map((e) => e.generateSyncMap()).join('\n')}
 
   ${methodTemplates.map((e) => e.generateCacheMap()).join('\n')}
+  ${getterTemplates.map((e) => e.generateCacheMap()).join('\n')}
 
   ${methodTemplates.map((e) => e.generateTtlMap()).join('\n')}
+  ${getterTemplates.map((e) => e.generateTtlMap()).join('\n')}
 
   ${streamedCacheMethodTemplates.map((e) => e.generateStreamMap()).join('\n')}
 
-  ${methodTemplates.map((e) => e.generateMethod()).join('\n\n')}
+  ${methodTemplates.map((e) => e.generate()).join('\n\n')}
+  ${getterTemplates.map((e) => e.generate()).join('\n\n')}
 
   ${streamedCacheMethodTemplates.map((e) => e.generateMethod()).join('\n\n')}
 

--- a/packages/cached/pubspec.yaml
+++ b/packages/cached/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   analyzer: ">=3.0.0 <5.0.0"
   build: ^2.3.0
-  cached_annotation:
+  cached_annotation: 
     path: "../cached_annotation"
   collection: ^1.16.0
   meta: ^1.7.0

--- a/packages/cached/test/cached_getter_generation_test.dart
+++ b/packages/cached/test/cached_getter_generation_test.dart
@@ -1,0 +1,32 @@
+import 'package:cached/src/cached_generator.dart';
+import 'package:cached/src/config.dart';
+import 'package:path/path.dart' as p;
+import 'package:source_gen_test/source_gen_test.dart';
+
+Future<void> main() async {
+  initializeBuildLogTracking();
+  const _expectedAnnotatedTests = {
+    'VoidGetter',
+    'FutureVoidGetter',
+    'AbstractGetter',
+    'Getter',
+    'AsyncGet',
+    'AsyncGeneratorGetter',
+    'SyncGeneratorGetter',
+    'CachedWithLimit',
+    'CachedWithTtl',
+    'AsyncSyncWrite',
+    'SyncSyncWrite',
+  };
+
+  final reader = await initializeLibraryReaderForDirectory(
+    p.join('test', 'inputs'),
+    'cached_getter_generation_test_input.dart',
+  );
+
+  testAnnotatedElements(
+    reader,
+    const CachedGenerator(config: Config()),
+    expectedAnnotatedTests: _expectedAnnotatedTests,
+  );
+}

--- a/packages/cached/test/inputs/cache_peek_method_generation_test_input.dart
+++ b/packages/cached/test/inputs/cache_peek_method_generation_test_input.dart
@@ -11,7 +11,7 @@ abstract class CachePeekMethodReturnType {
     return 1;
   }
 
-  @CachePeek(methodName: "cachedMethod")
+  @CachePeek("cachedMethod")
   String cachedPeek();
 }
 
@@ -25,7 +25,7 @@ abstract class MethodShouldExists {
     return 1;
   }
 
-  @CachePeek(methodName: "totallyWrongName")
+  @CachePeek("totallyWrongName")
   int? cachedPeek();
 }
 
@@ -39,7 +39,7 @@ abstract class MethodShouldHaveCachedAnnotation {
     return 1;
   }
 
-  @CachePeek(methodName: "cachedMethod")
+  @CachePeek("cachedMethod")
   int? cachedPeek();
 }
 
@@ -54,7 +54,7 @@ abstract class MethodShouldHaveSameParams {
     return y;
   }
 
-  @CachePeek(methodName: "cachedMethod")
+  @CachePeek("cachedMethod")
   int? cachedPeek(int z);
 }
 
@@ -70,7 +70,7 @@ abstract class MethodShouldHaveSameParamsNullable {
     return y;
   }
 
-  @CachePeek(methodName: "cachedMethod")
+  @CachePeek("cachedMethod")
   int? cachedPeek(int z);
 }
 
@@ -86,7 +86,7 @@ abstract class MethodShouldHaveSameParamsNoParams {
     return y;
   }
 
-  @CachePeek(methodName: "cachedMethod")
+  @CachePeek("cachedMethod")
   int? cachedPeek(int z);
 }
 
@@ -102,7 +102,7 @@ abstract class MethodShouldHaveSameParamsWithoutIgnore {
     return y;
   }
 
-  @CachePeek(methodName: "cachedMethod")
+  @CachePeek("cachedMethod")
   int? cachedPeek(int x);
 }
 
@@ -118,7 +118,7 @@ abstract class MethodShouldHaveSameParamsWithoutIgnoreCache {
     return y;
   }
 
-  @CachePeek(methodName: "cachedMethod")
+  @CachePeek("cachedMethod")
   int? cachedPeek(int x, bool ignoreCache);
 }
 
@@ -168,7 +168,7 @@ abstract class SimpleMethod {
     return 1;
   }
 
-  @CachePeek(methodName: "cachedMethod")
+  @CachePeek("cachedMethod")
   int? cachedPeek();
 }
 
@@ -218,7 +218,7 @@ abstract class FutureMethod {
     return 1;
   }
 
-  @CachePeek(methodName: "cachedMethod")
+  @CachePeek("cachedMethod")
   int? cachedPeek();
 }
 
@@ -268,7 +268,7 @@ abstract class Parameters {
     return 1;
   }
 
-  @CachePeek(methodName: "cachedMethod")
+  @CachePeek("cachedMethod")
   int? cachedPeek(String y);
 }
 
@@ -283,10 +283,10 @@ abstract class DuplicateTarget {
     return y;
   }
 
-  @CachePeek(methodName: "cachedMethod")
+  @CachePeek("cachedMethod")
   int? cachedPeek(int x);
 
-  @CachePeek(methodName: "cachedMethod")
+  @CachePeek("cachedMethod")
   int anotherSameCachePeek(int x);
 }
 
@@ -300,7 +300,7 @@ abstract class ShouldBeAbstract {
     return y;
   }
 
-  @CachePeek(methodName: "cachedMethod")
+  @CachePeek("cachedMethod")
   int? cachedPeek(int x) => 1;
 }
 
@@ -352,7 +352,7 @@ abstract class CachePeekWithCacheKey {
     return x[0];
   }
 
-  @CachePeek(methodName: "cachedMethod")
+  @CachePeek("cachedMethod")
   int? cachedPeek(@iterableCacheKey List<int> x);
 }
 
@@ -402,6 +402,6 @@ abstract class StaticCache {
     return y;
   }
 
-  @CachePeek(methodName: "cachedMethod")
+  @CachePeek("cachedMethod")
   int? cachedPeek(int x);
 }

--- a/packages/cached/test/inputs/cached_getter_generation_test_input.dart
+++ b/packages/cached/test/inputs/cached_getter_generation_test_input.dart
@@ -1,0 +1,401 @@
+import 'package:cached_annotation/cached_annotation.dart';
+import 'package:source_gen_test/annotations.dart';
+
+//MODIFIED CACHED METHOD GENERATION TEST INPUT
+
+@ShouldThrow(
+    '[ERROR] Method Getter returns void or Future<void> which is not allowed')
+@withCache
+abstract class VoidGetter {
+  factory VoidGetter() = _VoidGetter;
+
+  @cached
+  void get Getter {}
+}
+
+@ShouldThrow(
+    '[ERROR] Method Getter returns void or Future<void> which is not allowed')
+@withCache
+abstract class FutureVoidGetter {
+  factory FutureVoidGetter() = _FutureVoidGetter;
+
+  @cached
+  Future<void> get Getter async {}
+}
+
+@ShouldThrow('[ERROR] Cached method Getter is abstract which is not allowed')
+@withCache
+abstract class AbstractGetter {
+  factory AbstractGetter() = _AbstractGetter;
+
+  @cached
+  Future<int> get Getter;
+}
+
+@ShouldGenerate(
+  r'''
+abstract class _$Getter {}
+
+class _Getter with Getter implements _$Getter {
+  _Getter();
+
+  final _getterCached = <String, int>{};
+
+  @override
+  int get getter {
+    final cachedValue = _getterCached[""];
+    if (cachedValue == null) {
+      final int toReturn;
+      try {
+        final result = super.getter;
+
+        toReturn = result;
+      } catch (_) {
+        rethrow;
+      } finally {}
+
+      _getterCached[""] = toReturn;
+
+      return toReturn;
+    } else {
+      return cachedValue;
+    }
+  }
+}
+''',
+)
+@withCache
+abstract class Getter {
+  factory Getter() = _Getter;
+
+  @cached
+  int get getter {
+    return 1;
+  }
+}
+
+@ShouldGenerate(
+  r'''
+abstract class _$AsyncGet {}
+
+class _AsyncGet with AsyncGet implements _$AsyncGet {
+  _AsyncGet();
+
+  final _getterCached = <String, int>{};
+
+  @override
+  Future<int> get getter async {
+    final cachedValue = _getterCached[""];
+    if (cachedValue == null) {
+      final int toReturn;
+      try {
+        final result = super.getter;
+
+        toReturn = await result;
+      } catch (_) {
+        rethrow;
+      } finally {}
+
+      _getterCached[""] = toReturn;
+
+      return toReturn;
+    } else {
+      return cachedValue;
+    }
+  }
+}
+''',
+)
+@withCache
+abstract class AsyncGet {
+  factory AsyncGet() = _AsyncGet;
+
+  @cached
+  Future<int> get getter {
+    return Future.value(1);
+  }
+}
+
+@ShouldGenerate(
+  r'''
+abstract class _$AsyncGeneratorGetter {}
+
+class _AsyncGeneratorGetter
+    with AsyncGeneratorGetter
+    implements _$AsyncGeneratorGetter {
+  _AsyncGeneratorGetter();
+
+  final _getterCached = <String, Stream<int>>{};
+
+  @override
+  Stream<int> get getter async* {
+    final cachedValue = _getterCached[""];
+    if (cachedValue == null) {
+      final Stream<int> toReturn;
+      try {
+        final result = super.getter;
+
+        toReturn = result;
+      } catch (_) {
+        rethrow;
+      } finally {}
+
+      _getterCached[""] = toReturn;
+
+      yield* toReturn;
+    } else {
+      yield* cachedValue;
+    }
+  }
+}
+''',
+)
+@withCache
+abstract class AsyncGeneratorGetter {
+  factory AsyncGeneratorGetter() = _AsyncGeneratorGetter;
+
+  @cached
+  Stream<int> get getter async* {
+    yield 1;
+  }
+}
+
+@ShouldGenerate(
+  r'''
+abstract class _$SyncGeneratorGetter {}
+
+class _SyncGeneratorGetter
+    with SyncGeneratorGetter
+    implements _$SyncGeneratorGetter {
+  _SyncGeneratorGetter();
+
+  final _getterCached = <String, Iterable<int>>{};
+
+  @override
+  Iterable<int> get getter sync* {
+    final cachedValue = _getterCached[""];
+    if (cachedValue == null) {
+      final Iterable<int> toReturn;
+      try {
+        final result = super.getter;
+
+        toReturn = result;
+      } catch (_) {
+        rethrow;
+      } finally {}
+
+      _getterCached[""] = toReturn;
+
+      yield* toReturn;
+    } else {
+      yield* cachedValue;
+    }
+  }
+}
+''',
+)
+@withCache
+abstract class SyncGeneratorGetter {
+  factory SyncGeneratorGetter() = _SyncGeneratorGetter;
+
+  @cached
+  Iterable<int> get getter sync* {
+    yield 1;
+  }
+}
+
+@ShouldGenerate(
+  r'''
+abstract class _$CachedWithLimit {}
+
+class _CachedWithLimit with CachedWithLimit implements _$CachedWithLimit {
+  _CachedWithLimit();
+
+  final _getterCached = <String, int>{};
+
+  @override
+  int get getter {
+    final cachedValue = _getterCached[""];
+    if (cachedValue == null) {
+      final int toReturn;
+      try {
+        final result = super.getter;
+
+        toReturn = result;
+      } catch (_) {
+        rethrow;
+      } finally {}
+
+      _getterCached[""] = toReturn;
+
+      if (_getterCached.length > 10) {
+        _getterCached.remove(_getterCached.entries.last.key);
+      }
+
+      return toReturn;
+    } else {
+      return cachedValue;
+    }
+  }
+}
+''',
+)
+@withCache
+abstract class CachedWithLimit {
+  factory CachedWithLimit() = _CachedWithLimit;
+
+  @Cached(limit: 10)
+  int get getter {
+    return 1;
+  }
+}
+
+@ShouldGenerate(
+  r'''
+abstract class _$CachedWithTtl {}
+
+class _CachedWithTtl with CachedWithTtl implements _$CachedWithTtl {
+  _CachedWithTtl();
+
+  final _getterCached = <String, int>{};
+
+  final _getterTtl = <String, DateTime>{};
+
+  @override
+  int get getter {
+    final now = DateTime.now();
+    final currentTtl = _getterTtl[""];
+
+    if (currentTtl != null && currentTtl.isBefore(now)) {
+      _getterTtl.remove("");
+      _getterCached.remove("");
+    }
+
+    final cachedValue = _getterCached[""];
+    if (cachedValue == null) {
+      final int toReturn;
+      try {
+        final result = super.getter;
+
+        toReturn = result;
+      } catch (_) {
+        rethrow;
+      } finally {}
+
+      _getterCached[""] = toReturn;
+
+      _getterTtl[""] = DateTime.now().add(const Duration(seconds: 30));
+
+      return toReturn;
+    } else {
+      return cachedValue;
+    }
+  }
+}
+''',
+)
+@withCache
+abstract class CachedWithTtl {
+  factory CachedWithTtl() = _CachedWithTtl;
+
+  @Cached(ttl: 30)
+  int get getter {
+    return 1;
+  }
+}
+
+@ShouldGenerate(
+  r'''
+abstract class _$AsyncSyncWrite {}
+
+class _AsyncSyncWrite with AsyncSyncWrite implements _$AsyncSyncWrite {
+  _AsyncSyncWrite();
+
+  final _getterSync = <String, Future<int>>{};
+
+  final _getterCached = <String, int>{};
+
+  @override
+  Future<int> get getter async {
+    final cachedValue = _getterCached[""];
+    if (cachedValue == null) {
+      final cachedFuture = _getterSync[""];
+
+      if (cachedFuture != null) {
+        return cachedFuture;
+      }
+
+      final int toReturn;
+      try {
+        final result = super.getter;
+        _getterSync[''] = result;
+        toReturn = await result;
+      } catch (_) {
+        rethrow;
+      } finally {
+        _getterSync.remove('');
+      }
+
+      _getterCached[""] = toReturn;
+
+      return toReturn;
+    } else {
+      return cachedValue;
+    }
+  }
+}
+''',
+)
+@withCache
+abstract class AsyncSyncWrite {
+  factory AsyncSyncWrite() = _AsyncSyncWrite;
+
+  @Cached(syncWrite: true)
+  Future<int> get getter async {
+    return 1;
+  }
+}
+
+@ShouldGenerate(
+  r'''
+abstract class _$SyncSyncWrite {}
+
+class _SyncSyncWrite with SyncSyncWrite implements _$SyncSyncWrite {
+  _SyncSyncWrite();
+
+  final _getterSync = <String, Future<int>>{};
+
+  final _getterCached = <String, int>{};
+
+  @override
+  int get getter {
+    final cachedValue = _getterCached[""];
+    if (cachedValue == null) {
+      final int toReturn;
+      try {
+        final result = super.getter;
+
+        toReturn = result;
+      } catch (_) {
+        rethrow;
+      } finally {}
+
+      _getterCached[""] = toReturn;
+
+      return toReturn;
+    } else {
+      return cachedValue;
+    }
+  }
+}
+''',
+)
+@withCache
+abstract class SyncSyncWrite {
+  factory SyncSyncWrite() = _SyncSyncWrite;
+
+  @Cached(syncWrite: true)
+  int get getter {
+    return 1;
+  }
+}

--- a/packages/cached/test/inputs/cached_method_generation_test_input.dart
+++ b/packages/cached/test/inputs/cached_method_generation_test_input.dart
@@ -840,9 +840,7 @@ abstract class CacheKeyParam {
   factory CacheKeyParam() = _UseCacheKeyParam;
 
   @cached
-  int method(
-      {@CacheKey(cacheKeyGenerator: _cacheKeyGenerator)
-          bool something = false}) {
+  int method({@CacheKey(_cacheKeyGenerator) bool something = false}) {
     return 1;
   }
 }
@@ -854,9 +852,7 @@ abstract class IgnoreCacheWithCacheKeyParam {
 
   @cached
   int method(
-      {@IgnoreCache()
-      @CacheKey(cacheKeyGenerator: _cacheKeyGenerator)
-          bool something = false}) {
+      {@IgnoreCache() @CacheKey(_cacheKeyGenerator) bool something = false}) {
     return 1;
   }
 }

--- a/packages/cached/test/inputs/clear_cached_method_generation_test_input.dart
+++ b/packages/cached/test/inputs/clear_cached_method_generation_test_input.dart
@@ -17,7 +17,7 @@ abstract class NoTargetMethod {
 }
 
 @ShouldThrow(
-  '[ERROR] There are multiple methods which ClearCached annotation with the same argument',
+  '[ERROR] There are multiple targets with ClearCached annotation with the same argument',
   element: false,
 )
 @withCache
@@ -36,7 +36,7 @@ abstract class MultipleClearMethods {
   void clearCachedMethod();
 }
 
-@ShouldThrow('[ERROR] No cache method for `something` method', element: false)
+@ShouldThrow('[ERROR] No cache target for `something` method', element: false)
 @withCache
 abstract class InvalidName {
   factory InvalidName() = _InvalidName;

--- a/packages/cached/test/integration/async_integration_test.dart
+++ b/packages/cached/test/integration/async_integration_test.dart
@@ -94,6 +94,67 @@ void main() {
 
       expect(cachedValue, await next);
     });
+
+    test('cached value should be the same on the second getter call', () async {
+      final cachedClass = AsynchronousCached(_dataProvider);
+
+      final results = await Future.wait(
+        [cachedClass.syncCachedValueGetter, cachedClass.syncCachedValueGetter],
+      );
+
+      expect(results[0], equals(results[1]));
+    });
+
+    test('clear cache method should clear cache', () async {
+      final cachedClass = AsynchronousCached(_dataProvider);
+      final cachedValue = await cachedClass.syncCachedValueGetter;
+      cachedClass.clearCachedValueGetter();
+      final secondCachedValue = await cachedClass.syncCachedValueGetter;
+
+      expect(cachedValue != secondCachedValue, true);
+    });
+
+    test(
+        'cached getter with set TTL, should return old value when there is no timeout',
+        () async {
+      final cachedClass = AsynchronousCached(_dataProvider);
+
+      final cachedValueFuture = cachedClass.syncCachedValueGetterWithTTl;
+      await Future.delayed(const Duration(milliseconds: 10));
+      final secondCachedValueFuture = cachedClass.syncCachedValueGetterWithTTl;
+
+      await Future.wait([cachedValueFuture, secondCachedValueFuture]);
+      await Future.delayed(Duration(milliseconds: _slightlyLessThanTTL()));
+      await cachedClass.syncCachedValueGetterWithTTl;
+
+      expect(cachedClass.counter(), 1);
+    });
+
+    test('cached getter with set TTL, should return new value when TTL timeout',
+        () async {
+      final cachedClass = AsynchronousCached(_dataProvider);
+
+      final cachedValueFuture = cachedClass.syncCachedValueGetterWithTTl;
+      await Future.delayed(const Duration(milliseconds: 10));
+      final secondCachedValueFuture = cachedClass.syncCachedValueGetterWithTTl;
+
+      await Future.wait([cachedValueFuture, secondCachedValueFuture]);
+      await Future.delayed(const Duration(seconds: ttlDurationSeconds));
+      await cachedClass.syncCachedValueGetterWithTTl;
+
+      expect(cachedClass.counter(), 2);
+    });
+
+    test('cached stream works', () async {
+      final cachedClass = AsynchronousCached(_dataProvider);
+      final streamValue = StreamQueue(cachedClass.asyncCacheGetterStream());
+      final next = Future.microtask(() => streamValue.next);
+      await Future.delayed(Duration.zero);
+
+      final cachedValue = await cachedClass.asyncCachedValueGetter;
+
+      expect(cachedValue, await next);
+    });
   });
   group('AsynchronousCache with syncWrite: FALSE', () {
     late TestDataProvider _dataProvider;
@@ -148,6 +209,57 @@ void main() {
       final cachedClass = AsynchronousCached(_dataProvider);
       final cachedValue = await cachedClass.asyncCachedValue();
       final secondCachedValue = cachedClass.asyncCachePeek();
+
+      expect(cachedValue, equals(secondCachedValue));
+    });
+    test('two calls of the same async getter, should return different values',
+        () async {
+      final cachedClass = AsynchronousCached(_dataProvider);
+      final results = await Future.wait(
+        [
+          cachedClass.asyncCachedValueGetter,
+          cachedClass.asyncCachedValueGetter
+        ],
+      );
+
+      expect(results[0], isNot(equals(results[1])));
+    });
+
+    test(
+        'cached getter with set TTL, should return old value when there is no timeout',
+        () async {
+      final cachedClass = AsynchronousCached(_dataProvider);
+
+      final cachedValueFuture = cachedClass.asyncCachedValueGetterWithTTl;
+      await Future.delayed(const Duration(milliseconds: 10));
+      final secondCachedValueFuture = cachedClass.asyncCachedValueGetterWithTTl;
+
+      await Future.wait([cachedValueFuture, secondCachedValueFuture]);
+      await Future.delayed(Duration(milliseconds: _slightlyLessThanTTL()));
+
+      expect(cachedClass.counter(), 2);
+    });
+
+    test('cached method with set TTL, should return new value when TTL timeout',
+        () async {
+      final cachedClass = AsynchronousCached(_dataProvider);
+
+      final cachedValueFuture = cachedClass.asyncCachedValueGetterWithTTl;
+      await Future.delayed(const Duration(milliseconds: 10));
+      final secondCachedValueFuture = cachedClass.asyncCachedValueGetterWithTTl;
+
+      await Future.wait([cachedValueFuture, secondCachedValueFuture]);
+      await Future.delayed(const Duration(seconds: ttlDurationSeconds));
+      await cachedClass.asyncCachedValueGetterWithTTl;
+
+      expect(cachedClass.counter(), 3);
+    });
+
+    test('peek cache value should be the same on the async cached value',
+        () async {
+      final cachedClass = AsynchronousCached(_dataProvider);
+      final cachedValue = await cachedClass.asyncCachedValueGetter;
+      final secondCachedValue = cachedClass.asyncCacheGetterPeek();
 
       expect(cachedValue, equals(secondCachedValue));
     });

--- a/packages/cached/test/integration/asynchronous/cached_test_asynchronous.dart
+++ b/packages/cached/test/integration/asynchronous/cached_test_asynchronous.dart
@@ -54,7 +54,7 @@ abstract class AsynchronousCached implements _$AsynchronousCached {
   @StreamedCache(methodName: "asyncCachedValue", emitLastValue: false)
   Stream<int> asyncCacheStream();
 
-  @CachePeek(methodName: "asyncCachedValue")
+  @CachePeek("asyncCachedValue")
   int? asyncCachePeek();
 
   @ClearCached("asyncCachedValue")
@@ -75,6 +75,51 @@ abstract class AsynchronousCached implements _$AsynchronousCached {
   void resetCounter() => _counter = 0;
 
   int counter() => _counter;
+
+  @Cached(syncWrite: true)
+  Future<int> get syncCachedValueGetter {
+    return dataProvider.fetchRandomValue();
+  }
+
+  @StreamedCache(methodName: "syncCachedValueGetter", emitLastValue: false)
+  Stream<int> syncCachedValueGetterStream();
+
+  @StreamedCache(methodName: "asyncCachedValueGetter", emitLastValue: false)
+  Stream<int> asyncCacheGetterStream();
+
+  @Cached(ttl: ttlDurationSeconds, syncWrite: true)
+  Future<int> get syncCachedValueGetterWithTTl async {
+    _counter++;
+    await Future.delayed(const Duration(milliseconds: 100));
+    return dataProvider.fetchRandomValue();
+  }
+
+  @Cached(syncWrite: false)
+  Future<int> get asyncCachedValueGetter {
+    return dataProvider.fetchRandomValue();
+  }
+
+  @Cached(ttl: ttlDurationSeconds, syncWrite: false)
+  Future<int> get asyncCachedValueGetterWithTTl async {
+    _counter++;
+    await Future.delayed(const Duration(milliseconds: 100));
+    return dataProvider.fetchRandomValue();
+  }
+
+  @CachePeek("asyncCachedValueGetter")
+  int? asyncCacheGetterPeek();
+
+  @ClearCached("asyncCachedValueGetter")
+  Future<void> clearAsyncCachedValueGetter();
+
+  @ClearCached("asyncCachedValueGetterWithTTl")
+  void clearAsyncTTLCachedValueGetter();
+
+  @ClearCached("syncCachedValueGetter")
+  void clearCachedValueGetter();
+
+  @ClearCached("syncCachedValueGetterWithTTl")
+  void clearCachedValueGetterWithTTl();
 
   @DeletesCache(['asyncCachedValue'])
   Future<void> deleteAsyncCachedValue() async {

--- a/packages/cached/test/integration/simple/cached_test_simple.dart
+++ b/packages/cached/test/integration/simple/cached_test_simple.dart
@@ -22,7 +22,7 @@ abstract class SimpleCached implements _$SimpleCached {
 
   @cached
   int cachedValueWithCustomKey(
-    @CacheKey(cacheKeyGenerator: _cachedKeyGenerator) String value,
+    @CacheKey(_cachedKeyGenerator) String value,
   ) {
     return dataProvider.getRandomValue();
   }
@@ -75,15 +75,15 @@ abstract class SimpleCached implements _$SimpleCached {
   @StreamedCache(methodName: "nullableCachedValue", emitLastValue: true)
   Stream<int?> nullableCacheValueStream();
 
-  @CachePeek(methodName: "cachedValue")
+  @CachePeek("cachedValue")
   int? cachePeekValue();
 
-  @CachePeek(methodName: "cachedTimestamp")
+  @CachePeek("cachedTimestamp")
   int? timestampCachePeekValue();
 
-  @CachePeek(methodName: "cachedValueWithCustomKey")
+  @CachePeek("cachedValueWithCustomKey")
   int? peekCachedValueWithCustomKey(
-    @CacheKey(cacheKeyGenerator: _cachedKeyGenerator) String value,
+    @CacheKey(_cachedKeyGenerator) String value,
   );
 
   @clearCached
@@ -94,6 +94,34 @@ abstract class SimpleCached implements _$SimpleCached {
 
   @clearAllCached
   void clearAll();
+
+  @cached
+  int get cachedValueGetter {
+    return dataProvider.getRandomValue();
+  }
+
+  @cached
+  int? get nullableCachedValueGetter {
+    return null;
+  }
+
+  @StreamedCache(
+    methodName: "nullableCachedValueGetter",
+    emitLastValue: true,
+  )
+  Stream<int?> nullableCacheGetterValueStream();
+
+  @StreamedCache(methodName: "cachedValueGetter")
+  Stream<int> streamOfCachedGetterValue();
+
+  @CachePeek("nullableCachedValueGetter")
+  int? nullableCacheGetterPeekValue();
+
+  @CachePeek("cachedValueGetter")
+  int? cacheGetterPeekValue();
+
+  @clearCached
+  void clearCachedValueGetter();
 
   @DeletesCache(['cachedValue'])
   void deleteCachedValue() {}

--- a/packages/cached/test/integration/simple_integration_test.dart
+++ b/packages/cached/test/integration/simple_integration_test.dart
@@ -203,6 +203,84 @@ void main() {
       }
     });
 
+    test('cached value should be the same on the second getter call', () {
+      final cachedClass = SimpleCached(_dataProvider);
+      final cachedValue = cachedClass.cachedValueGetter;
+      final secondCachedValue = cachedClass.cachedValueGetter;
+
+      expect(cachedValue, equals(secondCachedValue));
+    });
+
+    test('clear cache method should clear getter cache', () {
+      final cachedClass = SimpleCached(_dataProvider);
+      final cachedValue = cachedClass.cachedValueGetter;
+      cachedClass.clearCachedValueGetter();
+      final secondCachedValue = cachedClass.cachedValueGetter;
+
+      expect(cachedValue != secondCachedValue, true);
+    });
+
+    test('calling other clear cache method, should not clear cache', () {
+      final cachedClass = SimpleCached(_dataProvider);
+      final cachedValue = cachedClass.cachedValueGetter;
+      cachedClass.clearCachedValue();
+      final secondCachedValue = cachedClass.cachedValueGetter;
+
+      expect(cachedValue == secondCachedValue, true);
+    });
+
+    test('clearing all cache method should clear cache', () async {
+      final cachedClass = SimpleCached(_dataProvider);
+      final cachedValue = cachedClass.cachedValueGetter;
+      await Future.delayed(const Duration(milliseconds: 10));
+
+      cachedClass.clearAll();
+      final secondCachedValue = cachedClass.cachedValueGetter;
+
+      expect(cachedValue != secondCachedValue, true);
+    });
+
+    test('cached value cache should be streamed', () async {
+      final cachedClass = SimpleCached(_dataProvider);
+
+      final queue = StreamQueue(cachedClass.streamOfCachedGetterValue());
+      final next = Future.microtask(() => queue.next);
+      await Future.delayed(Duration.zero);
+
+      final cachedValue = cachedClass.cachedValueGetter;
+
+      expect(cachedValue, await next);
+    });
+
+    test('stream should initial emit initialValue even if it is null',
+        () async {
+      final cachedClass = SimpleCached(_dataProvider);
+      cachedClass.nullableCachedValueGetter;
+
+      final streamValue =
+          StreamQueue(cachedClass.nullableCacheGetterValueStream());
+      expect(await streamValue.next, equals(null));
+    });
+
+    test('stream should not emit null if there is not initial value available',
+        () async {
+      final cachedClass = SimpleCached(_dataProvider);
+
+      final streamSub = cachedClass
+          .nullableCacheGetterValueStream()
+          .listen((event) => throw "Unexpected event");
+
+      await streamSub.cancel();
+    });
+
+    test('peek cache should be the same on cached value method', () {
+      final cachedClass = SimpleCached(_dataProvider);
+      final cachedValue = cachedClass.cachedValueGetter;
+      final secondCachedValue = cachedClass.cachedValueGetter;
+
+      expect(cachedValue, equals(secondCachedValue));
+    });
+
     test(
         'deletes cache method should clear cache if function returns with value',
         () {

--- a/packages/cached/test/integration/static/cached_test_static.dart
+++ b/packages/cached/test/integration/static/cached_test_static.dart
@@ -16,11 +16,22 @@ abstract class StaticCached implements _$StaticCached {
   @StreamedCache(methodName: "cachedValue")
   Stream<int> cachedValueCacheStream();
 
-  @CachePeek(methodName: "cachedValue")
+  @CachePeek("cachedValue")
   int? cachedValueCachePeek();
 
   @clearAllCached
   void clearCache();
+
+  @cached
+  int get cachedValueGetter {
+    return dataProvider.getRandomValue();
+  }
+
+  @StreamedCache(methodName: "cachedValueGetter")
+  Stream<int> cachedValueGetterCacheStream();
+
+  @CachePeek("cachedValueGetter")
+  int? cachedValueGetterCachePeek();
 
   @DeletesCache(['cachedValue'])
   void deleteCachedValue() {}

--- a/packages/cached/test/integration/static_integration_test.dart
+++ b/packages/cached/test/integration/static_integration_test.dart
@@ -47,6 +47,44 @@ void main() {
       expect(cachedValue, equals(cachedValueFromAnotherInstance));
     });
 
+    test("cache should be static", () {
+      final firstCachedClass = StaticCached(_dataProvider);
+      final secondsCachedClass = StaticCached(_dataProvider);
+
+      final cachedValue = firstCachedClass.cachedValueGetter;
+      final cachedValueFromAnotherInstance =
+          secondsCachedClass.cachedValueGetter;
+
+      expect(cachedValue, equals(cachedValueFromAnotherInstance));
+    });
+
+    test("stream should emit between instances", () async {
+      final firstCachedClass = StaticCached(_dataProvider);
+      final secondsCachedClass = StaticCached(_dataProvider);
+
+      final queue =
+          StreamQueue(secondsCachedClass.cachedValueGetterCacheStream());
+      final next = Future.microtask(() => queue.next);
+      await Future.delayed(Duration.zero);
+
+      final cachedValue = firstCachedClass.cachedValueGetter;
+
+      expect(cachedValue, equals(await next));
+    });
+
+    test('peek cache should be static', () {
+      final firstCachedClass = StaticCached(_dataProvider);
+      final secondsCachedClass = StaticCached(_dataProvider);
+
+      firstCachedClass.cachedValueGetter;
+
+      final cachedValue = firstCachedClass.cachedValueGetterCachePeek();
+      final cachedValueFromAnotherInstance =
+          secondsCachedClass.cachedValueGetterCachePeek();
+
+      expect(cachedValue, equals(cachedValueFromAnotherInstance));
+    });
+
     test(
         'deletes cache method should clear cache if function returns with value',
         () {

--- a/packages/cached_annotation/lib/src/cache_key.dart
+++ b/packages/cached_annotation/lib/src/cache_key.dart
@@ -29,13 +29,13 @@ typedef CacheKeyGeneratorFunc = String Function(dynamic);
 /// {@endtemplate}
 @Target({TargetKind.parameter})
 class CacheKey {
-  const CacheKey({required this.cacheKeyGenerator});
+  const CacheKey(this.cacheKeyGenerator);
 
   final CacheKeyGeneratorFunc cacheKeyGenerator;
 }
 
 /// const instance of [CacheKey] that uses [iterableCacheKeyGenerator]
-const iterableCacheKey = CacheKey(cacheKeyGenerator: iterableCacheKeyGenerator);
+const iterableCacheKey = CacheKey(iterableCacheKeyGenerator);
 
 /// Calculates good hashcode for list of values
 String iterableCacheKeyGenerator(dynamic l) {

--- a/packages/cached_annotation/lib/src/cache_peek.dart
+++ b/packages/cached_annotation/lib/src/cache_peek.dart
@@ -27,9 +27,9 @@ import 'package:meta/meta_meta.dart';
 @Target({TargetKind.method})
 class CachePeek {
   /// {@macro cached.cache_peek}
-  const CachePeek({
-    required this.methodName,
-  });
+  const CachePeek(
+    this.methodName,
+  );
 
   /// Name of method to be cache peek
   final String methodName;

--- a/packages/cached_annotation/lib/src/cached.dart
+++ b/packages/cached_annotation/lib/src/cached.dart
@@ -37,7 +37,7 @@ const cached = Cached();
 /// if you want to clear cache method use [ClearCached]
 /// or [ClearAllCached] annotation
 /// {@endtemplate}
-@Target({TargetKind.method})
+@Target({TargetKind.method, TargetKind.getter})
 class Cached {
   /// {@macro cached.cached}
   const Cached({

--- a/packages/cached_annotation/lib/src/deletes_cache.dart
+++ b/packages/cached_annotation/lib/src/deletes_cache.dart
@@ -40,7 +40,7 @@ import 'package:meta/meta_meta.dart';
 /// but if an error occurs, the cache is not deleted and the error is rethrown.
 ///
 /// {@endtemplate}
-@Target({TargetKind.method})
+@Target({TargetKind.method, TargetKind.getter})
 class DeletesCache {
   /// {@macro cached.deletes_cache}
   const DeletesCache(this.methodNames);


### PR DESCRIPTION
…k, added cached getters

CacheKey and CachePeek annotations do not have named arguments now:
![removed_named_arguments](https://user-images.githubusercontent.com/43029034/201638925-4bac37da-44ac-4738-af39-e3aa6d9c7ea3.png)

Changed logo size in readme:
![changed_logo_size](https://user-images.githubusercontent.com/43029034/201639164-99d191e8-a208-44b9-84ed-9678fa36f3bd.png)

Getters can be cached now:
![added_cached_getters](https://user-images.githubusercontent.com/43029034/201639366-79aa2bdc-857a-4ba2-831e-0cc0f586fcea.png)
![generated_code](https://user-images.githubusercontent.com/43029034/201639910-dcd9f21a-e363-41fb-82e9-e9456ad544f4.png)
