### PR TITLE
Feature/melos bootstrap

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   pull_request:
-    branches: [ master, develop, main ]
+    branches: [master, develop, main]
 
 jobs:
   build:
@@ -22,6 +22,9 @@ jobs:
       - name: Install coverage
         run: dart pub global activate coverage
 
+      - name: Melos Bootstrap
+        run: melos bs
+
       - name: Install dependencies
         run: melos run get
 
@@ -33,4 +36,3 @@ jobs:
 
       - name: Run tests
         run: melos run test:coverage
-        

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 .idea
 .DS_Store
 
+*.iml
+
+
 coverage/
 *.class
 *.log
@@ -13,3 +16,6 @@ coverage/
 .history
 .svn/
 coverage.lcov
+
+# Melos-generated file
+pubspec_overrides.yaml

--- a/melos.yaml
+++ b/melos.yaml
@@ -1,5 +1,9 @@
 name: cached
 
+command:
+  bootstrap:
+    usePubspecOverrides: true
+
 packages:
   - packages/**
 

--- a/packages/cached/example/pubspec.lock
+++ b/packages/cached/example/pubspec.lock
@@ -91,14 +91,14 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.3.1"
+    version: "1.4.0"
   cached_annotation:
     dependency: "direct main"
     description:
       path: "../../cached_annotation"
       relative: true
     source: path
-    version: "1.3.0"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:


### PR DESCRIPTION
Melos Bootstrap is optional, but simplifies local development a lot: we don't have to switch between local dependency (from path) and remember to change them before `pub.dev` publish.

Melos Bootstrap -> creates pubspec_overrides.yaml -> dart pub get resolves dependencies using local path

When push to pub.dev: no changes to paths necessary